### PR TITLE
Allow guzzlehttp 7 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "ext-json": ">=1.3.7",
     "ext-hash": ">=1",
     "psr/log": "~1.0",
-    "guzzlehttp/guzzle": "~6.0",
+    "guzzlehttp/guzzle": "~6.0|~7.0",
     "psr/simple-cache": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
Hi, we are running into dependency hell, as some of our dependencies requires guzzle 7 and this library is last one with guzzle 6 dependency. 

There are not many bc breaks and "should be fine": https://github.com/guzzle/guzzle/blob/master/UPGRADING.md#60-to-70 